### PR TITLE
修复“冷却时间控制”示例代码的错误

### DIFF
--- a/docs/notes/guide/8. 高级教程/1. 统一命令注册器/5. 过滤器系统.md
+++ b/docs/notes/guide/8. 高级教程/1. 统一命令注册器/5. 过滤器系统.md
@@ -279,37 +279,37 @@ class MyPlugin(NcatBotPlugin):
 ### 1. 冷却时间控制
 
 ```python
-from ncatbot.plugin_system.builtin_plugin.unified_registry.filter_system import CustomFilter
-from ncatbot.plugin_system.builtin_plugin.unified_registry.filter_system import filter_registry
+from ncatbot.core import BaseMessageEvent
+from ncatbot.plugin_system import NcatBotPlugin, command_registry
+from ncatbot.plugin_system.builtin_plugin.unified_registry import BaseFilter
 
-@filter_registry.register("cooldown")
-def cooldown_filter(event: BaseMessageEvent) -> bool:
-    """冷却时间过滤器 (60秒)"""
-    import time
-    user_id = event.user_id
-    current_time = time.time()
-    
-    if user_id in self.last_use:
-        if current_time - self.last_use[user_id] < 60:
-            return False  # 还在冷却中
-    
-    self.last_use[user_id] = current_time
-    return True
+class CooldownFilter(BaseFilter):
+    """冷却时间过滤器"""
+    def __init__(self, cd: float):
+        super().__init__()
+        self.cd = cd  # 记录冷却时间
+        self.last_use = {}  # 记录上次使用时间
+
+    def check(self, event: BaseMessageEvent) -> bool:
+        import time
+        user_id = event.user_id
+        current_time = time.time()
+
+        if user_id in self.last_use:
+            if current_time - self.last_use[user_id] < self.cd:
+                return False  # 还在冷却中
+
+        self.last_use[user_id] = current_time
+        return True
 
 class MyPlugin(NcatBotPlugin):
-    def __init__(self):
-        super().__init__()
-        self.last_use = {}  # 记录上次使用时间
-    
     async def on_load(self):
         pass
 
-
-    @filter_registry.filters("cooldown")
+    @CooldownFilter(60)  # 冷却时间设置为60秒
     @command_registry.command("limited")
     async def limited_command(self, event: BaseMessageEvent):
         await event.reply("有冷却限制的命令")
-    
 ```
 
 ## 🚦 下一步


### PR DESCRIPTION
原有的“高级教程”->“统一命令注册器”->“过滤器系统”->“常用过滤器模式”中的“冷却时间控制”示例代码在类外的过滤器函数中使用了self参数，这是错误的语法，在运行时会报错（没有运行时IDE也会提示错误）。
尽管将“last_use”移出过滤函数外作为全局参数也能解决问题，但代码并不优雅，这里修改为通过过滤器类实现冷却时间过滤器的功能。